### PR TITLE
无法正确加载配置

### DIFF
--- a/templates/app/src/dva.js
+++ b/templates/app/src/dva.js
@@ -1,11 +1,9 @@
 
-export default {
-  config() {
-    return {
-      onError(err) {
-        err.preventDefault();
-        console.error(err.message);
-      },
-    };
-  },
+export function config() {
+  return {
+    onError(err) {
+      err.preventDefault();
+      console.error(err.message);
+    },
+  };
 }


### PR DESCRIPTION
自动生成的 .umi/DvaContainer 的文件是 直接 使用config 属性，
但是require进来会有一个default，导致dva的配置失效
```
let app = dva({
  history: window.g_history,
  ...((require('/Users/dot/src/dva.js').config || (() => ({})))()),
});
```