### PR TITLE
fix(plugin): package.json 少了一个分号

### DIFF
--- a/lib/generators/plugin/templates/package.json
+++ b/lib/generators/plugin/templates/package.json
@@ -23,7 +23,7 @@
   "files": [
     "lib",
     "src"
-  ]
+  ],
   <% } else { %>
   "scripts": {
     "prepublishOnly": "np --no-cleanup --yolo --no-publish"


### PR DESCRIPTION
当在CLI里创建 `plugin` 时选择 `babel` 生成的 `package.json` 少了一个分号 。