### PR TITLE
fix typo

### DIFF
--- a/lib/generators/ant-design-pro/meta.json
+++ b/lib/generators/ant-design-pro/meta.json
@@ -1,3 +1,3 @@
 {
-  "description": "Create project with an layout-only ant-design-pro boilerplate, use together with umi block."
+  "description": "Create project with a layout-only ant-design-pro boilerplate, use together with umi block."
 }


### PR DESCRIPTION
`an` is used before words that start with vowels. `a` is used before words that start with consonants