### PR TITLE
fix: TS 项目下 addUmiExports 缺乏 API 类型推导的问题

### DIFF
--- a/lib/generators/app/templates/tsconfig.json
+++ b/lib/generators/app/templates/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@tmp/*": ["src/pages/.umi/*"]
     },
     "allowSyntheticDefaultImports": true
   }

--- a/lib/generators/block/templates/tsconfig.json
+++ b/lib/generators/block/templates/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@tmp/*": ["src/pages/.umi/*"]
     },
     "allowSyntheticDefaultImports": true
   }

--- a/lib/generators/library/templates/tsconfig.json
+++ b/lib/generators/library/templates/tsconfig.json
@@ -10,8 +10,7 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["src/*"],
-      "@tmp/*": ["src/pages/.umi/*"]
+      "@/*": ["src/*"]
     },
     "allowSyntheticDefaultImports": true
   }

--- a/lib/generators/library/templates/tsconfig.json
+++ b/lib/generators/library/templates/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@tmp/*": ["src/pages/.umi/*"]
     },
     "allowSyntheticDefaultImports": true
   }


### PR DESCRIPTION
#### 说明

tsconfig.json 增加对 @tmp 的路径定义以保证 addUmiExports 可顺利导出类型推导，配合解决 TS 项目下 addUmiExports 缺乏 API 类型推导的问题

ref: https://github.com/umijs/umi/pull/3600