### PR TITLE
fix(plugin): fix umi plugin template

### DIFF
--- a/lib/generators/plugin/templates/package.json
+++ b/lib/generators/plugin/templates/package.json
@@ -55,7 +55,6 @@
   },
   "gitHooks": {
     "pre-commit": "lint-staged",
-    "commit-msg": "node scripts/verifyCommit.js"
   },
   "files": [
 <% if (withUmiUI) { -%>

--- a/lib/generators/plugin/templates/test/fixtures/normal/pages/index.jsx
+++ b/lib/generators/plugin/templates/test/fixtures/normal/pages/index.jsx
@@ -4,7 +4,7 @@ import styles from './index.css';
 export default function() {
   return (
     <div className={styles.normal}>
-      <h1>Page index</h1>
+      <h1>hello umi plugin</h1>
     </div>
   );
 }

--- a/lib/generators/plugin/templates/test/fixtures/normal/pages/index.tsx
+++ b/lib/generators/plugin/templates/test/fixtures/normal/pages/index.tsx
@@ -5,7 +5,7 @@ import styles from './index.css';
 export default function() {
   return (
     <div className={styles.normal}>
-      <h1>Page index</h1>
+      <h1>hello umi plugin</h1>
     </div>
   );
 }


### PR DESCRIPTION
### 简介
- 修复 umi-plugin 模板 test 永远失败的问题
- 修复 umi-plugin 模板的 gitHooks 执行失败的问题 

### 主要变更
- 删除 gitHooks 里面执行 scripts/verifyCommit.js 的脚本，因为没有这个脚本文件
- 修改测试文件里的文案