### PR TITLE
fix: "babel-plugin-import" missing

### DIFF
--- a/lib/generators/plugin/templates/package.json
+++ b/lib/generators/plugin/templates/package.json
@@ -35,6 +35,7 @@
 <% } -%>
     "@umijs/test": "^3.0.10",
     "@umijs/test-utils": "^1.0.0",
+    "babel-plugin-import": "^1.13.3",
     "body-parser": "^1.18.2",
     "cross-env": "^6.0.3",
     "express": "^4.15.3",


### PR DESCRIPTION
## Problem
In plugin project template, .fatherrc.ts use babel-plugin-import, but "babel-plugin-import" is missing in package.json

## Solusion
add babel-plugin-import to devDependencies in package.json